### PR TITLE
Refactor/issue

### DIFF
--- a/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/controller/IssueController.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/controller/IssueController.java
@@ -2,7 +2,8 @@ package com.keepyuppy.KeepyUppy.issue.communication.controller;
 
 import com.keepyuppy.KeepyUppy.issue.communication.request.IssueRequest;
 import com.keepyuppy.KeepyUppy.issue.communication.request.IssueStatusRequest;
-import com.keepyuppy.KeepyUppy.issue.communication.response.IssueBoardResponse;
+import com.keepyuppy.KeepyUppy.issue.communication.response.TeamIssueBoardResponse;
+import com.keepyuppy.KeepyUppy.issue.communication.response.TeamIssueResponse;
 import com.keepyuppy.KeepyUppy.issue.communication.response.IssueResponse;
 import com.keepyuppy.KeepyUppy.issue.service.IssueService;
 import com.keepyuppy.KeepyUppy.security.jwt.CustomUserDetails;
@@ -78,7 +79,7 @@ public class IssueController {
 
     @GetMapping("/")
     @Operation(summary = "팀 이슈 보드 조회")
-    public ResponseEntity<IssueBoardResponse> getTeamIssueBoard(
+    public ResponseEntity<TeamIssueBoardResponse> getTeamIssueBoard(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long teamId) {
         return ResponseEntity.ok(issueService.getTeamIssueBoard(userDetails, teamId));

--- a/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/IssueResponse.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/IssueResponse.java
@@ -1,51 +1,23 @@
 package com.keepyuppy.KeepyUppy.issue.communication.response;
 
 import com.keepyuppy.KeepyUppy.issue.domain.entity.Issue;
-import com.keepyuppy.KeepyUppy.issue.domain.enums.IssueStatus;
-import com.keepyuppy.KeepyUppy.member.communication.response.MemberResponse;
+import com.keepyuppy.KeepyUppy.team.communication.response.TeamInContentResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
-
 @Data
-@Schema(name = "이슈 정보 응답")
-@AllArgsConstructor
-public class IssueResponse {
+@Schema(name = "팀 정보 포함한 이슈 정보 응답")
+public class IssueResponse extends TeamIssueResponse {
 
-    private Long id;
-    private String title;
-    private MemberResponse author;
-    private String content;
-    private List<MemberResponse> assignedMembers;
-    private LocalDate dueDate;
-    private IssueStatus status;
-    private String teamName;
-    private String teamColor;
+    private TeamInContentResponse team;
+
+    public IssueResponse(Issue issue) {
+        super(issue);
+        this.team = TeamInContentResponse.of(issue.getTeam());
+    }
 
     public static IssueResponse of(Issue issue){
-        return new IssueResponse(
-                issue.getId(),
-                issue.getTitle(),
-                MemberResponse.of(issue.getAuthor()),
-                issue.getContent(),
-                getMemberResponses(issue),
-                issue.getDueDate(),
-                issue.getStatus(),
-                issue.getTeam().getName(),
-                issue.getTeam().getColor()
-        );
+        return new IssueResponse(issue);
     }
-
-    public static List<MemberResponse> getMemberResponses(Issue issue){
-        if (issue.getIssueAssignments() == null) return Collections.emptyList();
-        return issue.getIssueAssignments().stream()
-                .map(assignment -> MemberResponse.of(assignment.getMember()))
-                .toList();
-    }
-
 
 }

--- a/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/TeamIssueBoardResponse.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/TeamIssueBoardResponse.java
@@ -1,0 +1,38 @@
+package com.keepyuppy.KeepyUppy.issue.communication.response;
+
+import com.keepyuppy.KeepyUppy.issue.domain.entity.Issue;
+import com.keepyuppy.KeepyUppy.team.communication.response.TeamInContentResponse;
+import com.keepyuppy.KeepyUppy.team.domain.entity.Team;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Schema(name = "팀 내 이슈 진행상태별 리스트 응답")
+@AllArgsConstructor
+public class TeamIssueBoardResponse {
+    private List<TeamIssueResponse> todoIssues;
+    private List<TeamIssueResponse> progressIssues;
+    private List<TeamIssueResponse> doneIssues;
+    private TeamInContentResponse team;
+
+    public static TeamIssueBoardResponse of(
+            List<Issue> todoIssues,
+            List<Issue> progressIssues,
+            List<Issue> doneIssues,
+            Team team
+    ){
+        return new TeamIssueBoardResponse(
+                getResponses(todoIssues),
+                getResponses(progressIssues),
+                getResponses(doneIssues),
+                TeamInContentResponse.of(team)
+        );
+    }
+
+    private static List<TeamIssueResponse> getResponses(List<Issue> issues){
+        return issues.stream().map(TeamIssueResponse::of).toList();
+    }
+}

--- a/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/TeamIssueResponse.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/TeamIssueResponse.java
@@ -1,0 +1,51 @@
+package com.keepyuppy.KeepyUppy.issue.communication.response;
+
+import com.keepyuppy.KeepyUppy.issue.domain.entity.Issue;
+import com.keepyuppy.KeepyUppy.issue.domain.enums.IssueStatus;
+import com.keepyuppy.KeepyUppy.member.communication.response.MemberResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+@Data
+@Schema(name = "팀 정보 제외한 이슈 정보 응답")
+public class TeamIssueResponse {
+
+    private Long id;
+    private String title;
+    private MemberResponse author;
+    private String content;
+    private List<MemberResponse> assignedMembers;
+    private LocalDate dueDate;
+    private IssueStatus status;
+
+    // default constructor for UserIssueResponse
+    public TeamIssueResponse() {}
+
+    public TeamIssueResponse(Issue issue) {
+        this.id = issue.getId();
+        this.title = issue.getTitle();
+        this.author = MemberResponse.of(issue.getAuthor());
+        this.content = issue.getContent();
+        this.assignedMembers = getMemberResponses(issue);
+        this.dueDate = issue.getDueDate();
+        this.status = issue.getStatus();
+    }
+
+    public static TeamIssueResponse of(Issue issue){
+        return new TeamIssueResponse(issue);
+    }
+
+    public static List<MemberResponse> getMemberResponses(Issue issue){
+        if (issue.getIssueAssignments() == null) return Collections.emptyList();
+        return issue.getIssueAssignments().stream()
+                .map(assignment -> MemberResponse.of(assignment.getMember()))
+                .toList();
+    }
+
+
+}

--- a/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/UserIssueBoardResponse.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/issue/communication/response/UserIssueBoardResponse.java
@@ -8,19 +8,19 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-@Schema(name = "이슈 진행상태별 리스트 응답")
+@Schema(name = "유저별 이슈 진행상태별 리스트 응답")
 @AllArgsConstructor
-public class IssueBoardResponse {
+public class UserIssueBoardResponse {
     private List<IssueResponse> todoIssues;
     private List<IssueResponse> progressIssues;
     private List<IssueResponse> doneIssues;
 
-    public static IssueBoardResponse of(
+    public static UserIssueBoardResponse of(
             List<Issue> todoIssues,
             List<Issue> progressIssues,
             List<Issue> doneIssues
     ){
-        return new IssueBoardResponse(
+        return new UserIssueBoardResponse(
                 getResponses(todoIssues),
                 getResponses(progressIssues),
                 getResponses(doneIssues)

--- a/src/main/java/com/keepyuppy/KeepyUppy/issue/service/IssueService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/issue/service/IssueService.java
@@ -4,8 +4,10 @@ import com.keepyuppy.KeepyUppy.global.exception.CustomException;
 import com.keepyuppy.KeepyUppy.global.exception.ExceptionType;
 import com.keepyuppy.KeepyUppy.issue.communication.request.IssueRequest;
 import com.keepyuppy.KeepyUppy.issue.communication.request.IssueStatusRequest;
-import com.keepyuppy.KeepyUppy.issue.communication.response.IssueBoardResponse;
 import com.keepyuppy.KeepyUppy.issue.communication.response.IssueResponse;
+import com.keepyuppy.KeepyUppy.issue.communication.response.TeamIssueBoardResponse;
+import com.keepyuppy.KeepyUppy.issue.communication.response.UserIssueBoardResponse;
+import com.keepyuppy.KeepyUppy.issue.communication.response.TeamIssueResponse;
 import com.keepyuppy.KeepyUppy.issue.domain.entity.Issue;
 import com.keepyuppy.KeepyUppy.issue.domain.entity.IssueAssignment;
 import com.keepyuppy.KeepyUppy.post.domain.enums.ContentType;
@@ -175,22 +177,22 @@ public class IssueService {
         });
     }
 
-    public IssueBoardResponse getTeamIssueBoard(CustomUserDetails userDetails, Long teamId){
+    public TeamIssueBoardResponse getTeamIssueBoard(CustomUserDetails userDetails, Long teamId){
         Member member = getMemberInTeam(userDetails.getUserId(), teamId);
 
         List<Issue> todo = issueJpaRepository.findByTeamAndStatusOrderByModifiedDateAsc(member.getTeam(), IssueStatus.TODO);
         List<Issue> progress = issueJpaRepository.findByTeamAndStatusOrderByModifiedDateAsc(member.getTeam(), IssueStatus.INPROGRESS);
         List<Issue> done = issueJpaRepository.findByTeamAndStatusOrderByModifiedDateAsc(member.getTeam(), IssueStatus.DONE);
 
-        return IssueBoardResponse.of(todo, progress, done);
+        return TeamIssueBoardResponse.of(todo, progress, done, member.getTeam());
     }
 
-    public IssueBoardResponse getMyIssueBoard(CustomUserDetails userDetails){
+    public UserIssueBoardResponse getMyIssueBoard(CustomUserDetails userDetails){
         List<Issue> todo = issueRepository.findByAssignedUserId(userDetails.getUserId(), IssueStatus.TODO);
         List<Issue> progress = issueRepository.findByAssignedUserId(userDetails.getUserId(), IssueStatus.INPROGRESS);
         List<Issue> done = issueRepository.findByAssignedUserId(userDetails.getUserId(), IssueStatus.DONE);
 
-        return IssueBoardResponse.of(todo, progress, done);
+        return UserIssueBoardResponse.of(todo, progress, done);
     }
 
 }

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/communication/controller/MemberController.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/communication/controller/MemberController.java
@@ -61,6 +61,16 @@ public class MemberController {
         memberService.reject(userDetails, teamId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "팀 내에서 유저네임 부분 일치 검색")
+    @GetMapping("/{teamId}/search")
+    public ResponseEntity<List<MemberResponse>> findMemberByUsernamePattern(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long teamId,
+            @RequestParam(defaultValue = "") String username
+    ){
+        return ResponseEntity.ok(memberService.findByUsernamePattern(userDetails, teamId, username));
+    }
 }
 
 

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/communication/response/MemberResponse.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/communication/response/MemberResponse.java
@@ -11,12 +11,14 @@ public class MemberResponse {
     private String imageUrl;
     private String role;
     private String grade;
+    private String username;
 
     public MemberResponse(Member member) {
         this.name = member.getUser() == null ? null : member.getUser().getName();
         this.imageUrl = member.getUser() == null ? null : member.getUser().getImageUrl();
         this.role = member.getRole() == null ? null : member.getRole().name();
         this.grade = member.getGrade().name();
+        this.username = member.getUser() == null ? null : member.getUser().getUsername();
     }
 
     public static MemberResponse of(Member member) {

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/repository/MemberRepositoryImpl.java
@@ -76,7 +76,7 @@ public class MemberRepositoryImpl {
 
     public List<Member> findMemberInTeamByUsernamePattern(String username, Long teamId) {
         return jpaQueryFactory.selectFrom(member)
-                .where(member.user.username.like(username + "%")
+                .where(member.user.username.lower().like(username + "%")
                         .and(member.team.id.eq(teamId)))
                 .fetch();
     }

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/repository/MemberRepositoryImpl.java
@@ -73,6 +73,13 @@ public class MemberRepositoryImpl {
                         .fetchOne()
         );
     }
+
+    public List<Member> findMemberInTeamByUsernamePattern(String username, Long teamId) {
+        return jpaQueryFactory.selectFrom(member)
+                .where(member.user.username.like(username + "%")
+                        .and(member.team.id.eq(teamId)))
+                .fetch();
+    }
 }
 
 

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/service/MemberService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/service/MemberService.java
@@ -116,9 +116,8 @@ public class MemberService {
     public List<MemberResponse> findByUsernamePattern(CustomUserDetails userDetails, Long teamId, String username) {
         findMemberInTeamByUserId(userDetails.getUserId(), teamId);
 
-        return memberRepository.findMemberInTeamByUsernamePattern(username, teamId).stream()
-                .map(MemberResponse::of)
-                .toList();
+        return memberRepository.findMemberInTeamByUsernamePattern(username.toLowerCase(), teamId)
+                .stream().map(MemberResponse::of).toList();
     }
 
     private Member findMemberInTeamByUserId(Long userId, Long teamId) {

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/service/MemberService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/service/MemberService.java
@@ -113,8 +113,16 @@ public class MemberService {
         return member.update(updater, updateMemberRequest);
     }
 
+    public List<MemberResponse> findByUsernamePattern(CustomUserDetails userDetails, Long teamId, String username) {
+        findMemberInTeamByUserId(userDetails.getUserId(), teamId);
+
+        return memberRepository.findMemberInTeamByUsernamePattern(username, teamId).stream()
+                .map(MemberResponse::of)
+                .toList();
+    }
+
     private Member findMemberInTeamByUserId(Long userId, Long teamId) {
-        return memberRepository.findMemberInTeamByUserId(userId, teamId).orElseThrow(() -> new CustomException(ExceptionType.MEMBER_NOT_FOUND));
+        return memberRepository.findMemberInTeamByUserId(userId, teamId).orElseThrow(() -> new CustomException(ExceptionType.TEAM_ACCESS_DENIED));
     }
 
     private Team findTeamById(Long teamId) {

--- a/src/main/java/com/keepyuppy/KeepyUppy/schedule/communication/response/TeamScheduleResponse.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/schedule/communication/response/TeamScheduleResponse.java
@@ -3,7 +3,7 @@ package com.keepyuppy.KeepyUppy.schedule.communication.response;
 import com.keepyuppy.KeepyUppy.member.communication.response.MemberResponse;
 import com.keepyuppy.KeepyUppy.member.domain.entity.Member;
 import com.keepyuppy.KeepyUppy.schedule.domain.entity.Schedule;
-import com.keepyuppy.KeepyUppy.team.communication.response.TeamInScheduleResponse;
+import com.keepyuppy.KeepyUppy.team.communication.response.TeamInContentResponse;
 import com.keepyuppy.KeepyUppy.team.domain.entity.Team;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -16,11 +16,11 @@ import java.time.LocalDateTime;
 @Data
 public class TeamScheduleResponse extends ScheduleResponse {
     private MemberResponse memberResponse;
-    private TeamInScheduleResponse teamInScheduleResponse;
+    private TeamInContentResponse teamInScheduleResponse;
 
     public TeamScheduleResponse(Member member, Team team, String title, String content, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         this.memberResponse = MemberResponse.of(member);
-        this.teamInScheduleResponse = TeamInScheduleResponse.of(team);
+        this.teamInScheduleResponse = TeamInContentResponse.of(team);
         setTitle(title);
         setContent(content);
         setStartDateTime(startDateTime);

--- a/src/main/java/com/keepyuppy/KeepyUppy/team/communication/response/TeamInContentResponse.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/team/communication/response/TeamInContentResponse.java
@@ -6,20 +6,20 @@ import lombok.Data;
 
 @Data
 @Schema(name = "팀 스케쥴 팀 정보")
-public class TeamInScheduleResponse {
+public class TeamInContentResponse {
     private Long id;
     private String name;
     private String description;
     private String color;
 
-    private TeamInScheduleResponse(Long id, String name, String description, String color) {
+    private TeamInContentResponse(Long id, String name, String description, String color) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.color = color;
     }
 
-    public static TeamInScheduleResponse of(Team team) {
-        return new TeamInScheduleResponse(team.getId(), team.getName(), team.getDescription(), team.getColor());
+    public static TeamInContentResponse of(Team team) {
+        return new TeamInContentResponse(team.getId(), team.getName(), team.getDescription(), team.getColor());
     }
 }

--- a/src/main/java/com/keepyuppy/KeepyUppy/user/communication/controller/UserController.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/user/communication/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.keepyuppy.KeepyUppy.user.communication.controller;
 
-import com.keepyuppy.KeepyUppy.issue.communication.response.IssueBoardResponse;
+import com.keepyuppy.KeepyUppy.issue.communication.response.UserIssueBoardResponse;
 import com.keepyuppy.KeepyUppy.issue.service.IssueService;
 import com.keepyuppy.KeepyUppy.post.communication.response.AnnouncementResponse;
 import com.keepyuppy.KeepyUppy.post.service.AnnouncementService;
@@ -71,7 +71,7 @@ public class UserController {
 
     @GetMapping( "/myIssue")
     @Operation(summary = "내 이슈 조회")
-    public ResponseEntity<IssueBoardResponse> getMyIssues(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<UserIssueBoardResponse> getMyIssues(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(issueService.getMyIssueBoard(userDetails));
     }
 

--- a/src/main/java/com/keepyuppy/KeepyUppy/user/service/UserService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/user/service/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final S3Service s3Service;
 
-    private static final Pattern USERNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_]+$");
+    private static final Pattern USERNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
 
     @Transactional
     public Users updateUser(Long id, UpdateUserRequest request){
@@ -40,7 +40,7 @@ public class UserService {
         } else if (username.length() < 5 || username.length() > 30) {
         throw new IllegalArgumentException("유저네임은 5자 이상, 30자 이하여야 합니다.");
         } else if (!USERNAME_PATTERN.matcher(username).matches()){
-            throw new IllegalArgumentException("알파벳, 숫자, 밑줄(_)만 사용할 수 있습니다.");
+            throw new IllegalArgumentException("알파벳, 숫자, 밑줄(_), 줄표(-)만 사용할 수 있습니다.");
         } else if (existsByUsername(username)){
             throw new IllegalArgumentException("이미 사용중인 유저네임입니다.");
         }


### PR DESCRIPTION
팀 이슈보드 응답에 팀 중복으로 보내지 않기
이슈 생성할 때 유저네임 검색 (멤버 내에서 인풋과 유저네임 겹치는 유저 모두 리턴)

2가지 완료했습니다!
추가로 멤버 응답에서 유저네임도 포함하면 좋을 것 같아서 그 부분 추가했고 teamInScheduleResponse를 이슈에서도 쓰게 되어서 이름 변경했습니다