### PR TITLE
Feat/my post

### DIFF
--- a/src/main/java/com/keepyuppy/KeepyUppy/member/communication/request/AddMemberRequest.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/communication/request/AddMemberRequest.java
@@ -6,5 +6,5 @@ import lombok.Data;
 @Data
 @Schema(name = "멤버 추가 요청")
 public class AddMemberRequest {
-    private String userName;
+    private String username;
 }

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/communication/request/RemoveMemberRequest.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/communication/request/RemoveMemberRequest.java
@@ -6,5 +6,5 @@ import lombok.Data;
 @Data
 @Schema(name = "멤버 삭제 요청")
 public class RemoveMemberRequest {
-    private String memberName;
+    private String username;
 }

--- a/src/main/java/com/keepyuppy/KeepyUppy/member/service/MemberService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/member/service/MemberService.java
@@ -49,7 +49,7 @@ public class MemberService {
 
             Users user = findUserById(userDetails.getUserId());
 
-            if (alreadyMemberInTeam(addMemberRequest.getUserName(), teamId)) {
+            if (alreadyMemberInTeam(addMemberRequest.getUsername(), teamId)) {
                 throw new CustomException(ExceptionType.MEMBER_ALREADY_EXISTS);
             }
 
@@ -71,7 +71,7 @@ public class MemberService {
 
         Team team = findTeamById(teamId);
 
-        Member member = findMemberInTeamByUserName(removeMemberRequest.getMemberName(), teamId);
+        Member member = findMemberInTeamByUserName(removeMemberRequest.getUsername(), teamId);
 
         if (member.canUpdate(loginMember)) {
             memberJpaRepository.delete(member);

--- a/src/main/java/com/keepyuppy/KeepyUppy/post/communication/controller/PostController.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/post/communication/controller/PostController.java
@@ -3,9 +3,6 @@ package com.keepyuppy.KeepyUppy.post.communication.controller;
 import com.keepyuppy.KeepyUppy.post.communication.request.PostRequest;
 import com.keepyuppy.KeepyUppy.post.communication.response.AnnouncementResponse;
 import com.keepyuppy.KeepyUppy.post.communication.response.PostResponse;
-import com.keepyuppy.KeepyUppy.post.domain.entity.Announcement;
-import com.keepyuppy.KeepyUppy.post.domain.enums.ContentType;
-import com.keepyuppy.KeepyUppy.post.service.AnnouncementService;
 import com.keepyuppy.KeepyUppy.post.service.PostService;
 import com.keepyuppy.KeepyUppy.security.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -85,6 +82,6 @@ public class PostController {
             @PathVariable Long teamId,
             @RequestParam(defaultValue = "1") int page) {
 
-        return ResponseEntity.ok(postService.getPostPaginate(userDetails, teamId, page));
+        return ResponseEntity.ok(postService.getPostPaginateByTeam(userDetails, teamId, page));
     }
 }

--- a/src/main/java/com/keepyuppy/KeepyUppy/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/post/repository/PostRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.keepyuppy.KeepyUppy.post.repository;
+
+import com.keepyuppy.KeepyUppy.post.domain.entity.Post;
+import com.keepyuppy.KeepyUppy.post.domain.enums.ContentType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.keepyuppy.KeepyUppy.post.domain.entity.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryImpl {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Page<Post> findByUserId(Long userId, ContentType type, Pageable pageable) {
+        List<Post> content = jpaQueryFactory.selectFrom(post)
+                .where(post.team.members.any().user.id.eq(userId)
+                        .and(post.type.eq(type)))
+                .orderBy(post.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory.select(post.count())
+                .from(post)
+                .where(post.team.members.any().user.id.eq(userId))
+                .fetchOne();
+        total = total == null ? 0 : total;
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+}

--- a/src/main/java/com/keepyuppy/KeepyUppy/post/service/PostService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/post/service/PostService.java
@@ -13,6 +13,7 @@ import com.keepyuppy.KeepyUppy.post.repository.PostJpaRepository;
 import com.keepyuppy.KeepyUppy.member.domain.entity.Member;
 import com.keepyuppy.KeepyUppy.member.domain.enums.Grade;
 import com.keepyuppy.KeepyUppy.member.repository.MemberRepositoryImpl;
+import com.keepyuppy.KeepyUppy.post.repository.PostRepositoryImpl;
 import com.keepyuppy.KeepyUppy.security.jwt.CustomUserDetails;
 import com.keepyuppy.KeepyUppy.team.domain.entity.Team;
 import jakarta.transaction.Transactional;
@@ -30,6 +31,7 @@ import java.util.Objects;
 public class PostService {
 
     private final PostJpaRepository postJpaRepository;
+    private final PostRepositoryImpl postRepository;
     private final AnnouncementJPARepository announcementJPARepository;
     private final MemberRepositoryImpl memberRepository;
 
@@ -116,7 +118,7 @@ public class PostService {
     }
 
     // sorted by created date (newer posts on top)
-    public Page<PostResponse> getPostPaginate(
+    public Page<PostResponse> getPostPaginateByTeam(
             CustomUserDetails userDetails,
             Long teamId,
             int page) {
@@ -125,6 +127,17 @@ public class PostService {
 
         Pageable pageable = PageRequest.of(page - 1, 10);
         Page<Post> posts = postJpaRepository.findByTeamAndTypeOrderByCreatedDateDesc(member.getTeam(), ContentType.POST, pageable);
+
+        return posts.map(PostResponse::of);
+    }
+
+    // sorted by created date (newer posts on top)
+    public Page<PostResponse> getPostPaginateByUser(
+            CustomUserDetails userDetails,
+            int page) {
+
+        Pageable pageable = PageRequest.of(page - 1, 10);
+        Page<Post> posts = postRepository.findByUserId(userDetails.getUserId(), ContentType.POST, pageable);
 
         return posts.map(PostResponse::of);
     }

--- a/src/main/java/com/keepyuppy/KeepyUppy/team/communication/request/ChangeTeamOwnerRequest.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/team/communication/request/ChangeTeamOwnerRequest.java
@@ -8,5 +8,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Schema(name = "팀 소유자 변경 요청")
 public class ChangeTeamOwnerRequest {
-    private String newOwnerName;
+    private String username;
 }

--- a/src/main/java/com/keepyuppy/KeepyUppy/team/service/TeamService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/team/service/TeamService.java
@@ -107,7 +107,7 @@ public class TeamService {
     public boolean changeTeamOwner(CustomUserDetails userDetails, Long teamId, ChangeTeamOwnerRequest changeTeamOwnerRequest) {
         Team team = teamJpaRepository.findById(teamId).orElseThrow(() -> new CustomException(ExceptionType.TEAM_NOT_FOUND));
         Member beforeOwner = getMemberByUsernameAndTeamId(userDetails.getUsername(), teamId);
-        Member afterOwner = getMemberByUsernameAndTeamId(changeTeamOwnerRequest.getNewOwnerName(), teamId);
+        Member afterOwner = getMemberByUsernameAndTeamId(changeTeamOwnerRequest.getUsername(), teamId);
 
         if (beforeOwner.getGrade().equals(Grade.OWNER)) {
             afterOwner.setGrade(Grade.OWNER);

--- a/src/main/java/com/keepyuppy/KeepyUppy/user/communication/controller/UserController.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/user/communication/controller/UserController.java
@@ -3,7 +3,9 @@ package com.keepyuppy.KeepyUppy.user.communication.controller;
 import com.keepyuppy.KeepyUppy.issue.communication.response.UserIssueBoardResponse;
 import com.keepyuppy.KeepyUppy.issue.service.IssueService;
 import com.keepyuppy.KeepyUppy.post.communication.response.AnnouncementResponse;
+import com.keepyuppy.KeepyUppy.post.communication.response.PostResponse;
 import com.keepyuppy.KeepyUppy.post.service.AnnouncementService;
+import com.keepyuppy.KeepyUppy.post.service.PostService;
 import com.keepyuppy.KeepyUppy.security.jwt.CustomUserDetails;
 import com.keepyuppy.KeepyUppy.user.communication.request.UpdateUserRequest;
 import com.keepyuppy.KeepyUppy.user.communication.response.UserResponse;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,6 +33,7 @@ public class UserController {
 
     private final UserService userService;
     private final IssueService issueService;
+    private final PostService postService;
     private final AnnouncementService announcementService;
 
     @GetMapping("/")
@@ -56,7 +60,7 @@ public class UserController {
         return ResponseEntity.ok("회원 탈퇴 성공");
     }
 
-    @GetMapping("/checkUsername/{username}")
+    @GetMapping("/check-username/{username}")
     @Operation(summary = "유저네임 중복 확인")
     public ResponseEntity<Boolean> checkUsername(@PathVariable String username) {
         boolean exists = userService.existsByUsername(username);
@@ -69,7 +73,7 @@ public class UserController {
         userService.updateProfileImage(userDetails, multipartFile);
     }
 
-    @GetMapping("/myIssue")
+    @GetMapping("/my-issue")
     @Operation(summary = "내 이슈 조회")
     public ResponseEntity<UserIssueBoardResponse> getMyIssues(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(issueService.getMyIssueBoard(userDetails));
@@ -90,10 +94,19 @@ public class UserController {
         return ResponseEntity.ok("공지 읽음 표시 성공");
     }
 
-    @Operation(summary = "유저네임 이 일치하는 유저 조회")
+    @Operation(summary = "유저네임이 일치하는 유저 조회")
     @GetMapping("/search")
     public ResponseEntity<UserResponse> findByUsername(@RequestParam String username) {
         return ResponseEntity.ok(userService.findByUsername(username));
+    }
+
+    @Operation(summary = "팀 통합 자유게시판 조회")
+    @GetMapping("/all-post")
+    public ResponseEntity<Page<PostResponse>> getUserPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "1") int page
+    ){
+        return ResponseEntity.ok(postService.getPostPaginateByUser(userDetails, page));
     }
 }
 


### PR DESCRIPTION
통합 게시판 엔드포인트 만들면서 유저 컨트롤러에서 api 루트 몇개만 수정했습니다
그리고 userName이 혼용되면서 원하는게 이름인지 유저네임인지 헷갈리는 것 같아서 다 username으로 통일했습니다!

팀 여러개에 속해있을때도 잘 작동되나 테스트 하려고 이미 생성된 팀에서 초대를 해보는데 초대를 해도 pending에 뜨지 않거나, 같은 유저네임으로 다시 초대를 보냈을 때 MEMBER_ALREADY_EXISTS 대신 쿼리 에러가 떠서 멤버 초대 부분 로직 다시 한번 봐주셨으면 좋겠습니다! 
저도 봐보긴 했는데 코드상으로는 문제가 없어보여서 잘 모르겠네요

그리고 유저스케줄은 본인이 아니어도 조회가 되는건가요?  path에 userId가 들어가는데 본인 스케줄만 조회할 수 있는거면 @AuthenticationPrincipal에서 따와야할 것 같습니다! 