### PR TITLE
refactor[Team]: fix setOwnerId, MemberAlReadyException if add members…

### DIFF
--- a/src/main/java/com/keepyuppy/KeepyUppy/team/service/TeamService.java
+++ b/src/main/java/com/keepyuppy/KeepyUppy/team/service/TeamService.java
@@ -49,7 +49,7 @@ public class TeamService {
 
         List<String> members = createTeamRequest.getMembers();
 
-        if (members.contains(user.getUsername())) {
+        if (members != null && members.contains(user.getUsername())) {
             throw new CustomException(ExceptionType.MEMBER_ALREADY_EXISTS);
         }
 
@@ -57,11 +57,11 @@ public class TeamService {
 
         team.addMember(member);
 
-        team.setOwnerId(member.getId());
-
         teamJpaRepository.save(team);
 
         memberJpaRepository.save(member);
+
+        team.setOwnerId(member.getId());
 
         if (createTeamRequest.getMembers() != null) {
             createTeamRequest.getMembers().forEach(memberName -> {

--- a/src/test/java/com/keepyuppy/KeepyUppy/TeamTest.java
+++ b/src/test/java/com/keepyuppy/KeepyUppy/TeamTest.java
@@ -53,11 +53,13 @@ class TeamTest {
 
         //when
         TeamResponse team = teamService.createTeam(customUserDetails, createTeamRequest);
+        Team team1 = teamJpaRepository.findById(1L).get();
 
         //then
         Assertions.assertEquals("A팀",team.getName());
         Assertions.assertEquals(teamOwner.getUsername(),team.getMembers().get(0).getUsername());
         Assertions.assertEquals(Grade.OWNER.name(),team.getMembers().get(0).getGrade());
+        Assertions.assertEquals(1L,team1.getOwnerId());
     }
 
     @Test


### PR DESCRIPTION
- 팀을 생성할때 팀 생성한 유저가 팀의 멤버로 저장이 되는데
setOwnerId 를 Member 저장 전에 실행하여 null 로 저장되고 있던 부분을 수정하였습니다.
- members 가 null 일경우 contains 조건문에서 Exception 이 발생하여 조건문을 추가하였습니다.